### PR TITLE
Nidi/use default shell

### DIFF
--- a/src/Tool/src/Boost.Core/Workspace/WorkspaceService.cs
+++ b/src/Tool/src/Boost.Core/Workspace/WorkspaceService.cs
@@ -256,7 +256,7 @@ namespace Boost.Workspace
 
         public Task<int> OpenInExplorer(string directory)
         {
-            IWebShell shell = _webShellFactory.CreateShell("pwsh");
+            IWebShell shell = _webShellFactory.CreateShell();
             var cmd = new ShellCommand("ii")
             {
                 Arguments = ".",
@@ -268,7 +268,7 @@ namespace Boost.Workspace
 
         public Task<int> OpenInTerminal(string directory)
         {
-            IWebShell shell = _webShellFactory.CreateShell("pwsh");
+            IWebShell shell = _webShellFactory.CreateShell();
             var cmd = new ShellCommand("wt.exe")
             {
                 Arguments = $"-w 0 nt -d {directory}",

--- a/src/Tool/src/Boost.Core/Workspace/WorkspaceService.cs
+++ b/src/Tool/src/Boost.Core/Workspace/WorkspaceService.cs
@@ -93,7 +93,7 @@ namespace Boost.Workspace
 
         public async Task<int> ExecuteFileActionAsync(string fileName, string action)
         {
-            FileInfo? file = new FileInfo(fileName);
+            FileInfo file = new(fileName);
 
             switch (action)
             {


### PR DESCRIPTION
Summary of the changes (Less than 80 chars)

- use default shell instead of hard-coded shell command. Fixes exception if "pwsh" is not installed.
