### PR TITLE
Fix saving auth requests

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -13,7 +13,7 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <Version Condition="$(Version) == ''">0.3.4</Version>
+    <Version Condition="$(Version) == ''">0.3.6</Version>
     <Product>Boost</Product>
     <Authors>Philippe Birbaum</Authors>
     <Company>Swiss Life</Company>

--- a/src/Tool/src/Boost.Abstractions/Security/IIdentityRequestStore.cs
+++ b/src/Tool/src/Boost.Abstractions/Security/IIdentityRequestStore.cs
@@ -73,6 +73,8 @@ namespace Boost.Security
         public bool SaveTokens { get; set; }
 
         public IEnumerable<TokenRequestParameter>? Parameters { get; set; }
+
+        public IEnumerable<string>? ResponseTypes { get; set; }
     }
 
     public enum IdentityRequestType

--- a/src/UI/boost-ui/src/core/components/Security/SaveIdentityRequestMenu.vue
+++ b/src/UI/boost-ui/src/core/components/Security/SaveIdentityRequestMenu.vue
@@ -103,6 +103,7 @@ export default {
           port: this.data.port,
           usePkce: this.data.usePkce,
           saveTokens: this.data.saveTokens,
+          responseTypes: this.data.responseTypes,
           parameters: this.parameters.map((x) => {
             return {
               name: x.name,

--- a/src/UI/boost-ui/src/core/components/Security/SaveIdentityRequestMenu.vue
+++ b/src/UI/boost-ui/src/core/components/Security/SaveIdentityRequestMenu.vue
@@ -94,14 +94,22 @@ export default {
         id: this.request.id,
         type: this.request.type,
         tags: this.request.tags,
-        data: Object.assign(this.data, {
+        data: {
+          authority: this.data.authority,
+          clientId: this.data.clientId,
+          secret: this.data.secret,
+          grantType: this.data.grantType,
+          scopes: this.data.scopes,
+          port: this.data.port,
+          usePkce: this.data.usePkce,
+          saveTokens: this.data.saveTokens,
           parameters: this.parameters.map((x) => {
             return {
               name: x.name,
               value: x.value,
             };
-          }),
-        }),
+          })
+        },
       };
 
       this.menu = false;

--- a/src/UI/boost-ui/src/core/graphql/Security/GetIdentityRequest.gql
+++ b/src/UI/boost-ui/src/core/graphql/Security/GetIdentityRequest.gql
@@ -15,6 +15,7 @@ query getIdentityRequest($id: UUID!) {
       scopes
       usePkce
       saveTokens
+      responseTypes
      parameters{
        name
        value


### PR DESCRIPTION
Saving authorize requests in Boost | Security | Authorize was broken because `this.data` was directly used as input in a GraphQL input. When this.data gained an additional field the save functionality was broken as the input had more fields than the GraphQL schema allowed. This is fixed in this pr.

